### PR TITLE
Deploy SuperVanish to Maven repository

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,34 @@
+image: maven:3-jdk-9-slim
+
+cache:
+  paths:
+  - .m2/repository
+
+variables:
+  MAVEN_OPTS: "-Dmaven.repo.local=.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
+  MAVEN_CLI_OPTS: "--batch-mode --errors --fail-at-end --show-version -DinstallAtEnd=true -DdeployAtEnd=true"
+
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  script:
+  - apt update
+  - apt install wget -y
+  - wget https://gitlab.com/cubekrowd/mavenrepo/raw/master/build2.sh
+  - bash build2.sh
+  artifacts:
+    paths:
+    - "*.jar"
+
+deploy:
+  stage: deploy
+  script:
+  - apt update
+  - apt install wget -y
+  - wget https://gitlab.com/cubekrowd/mavenrepo/raw/master/deploy1.sh
+  - bash deploy1.sh
+  only:
+  - master

--- a/pom.xml
+++ b/pom.xml
@@ -8,16 +8,38 @@
     <artifactId>SuperVanish</artifactId>
     <version>5.10.1</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>cubekrowd-repo</id>
+            <name>cubekrowd-public-releases</name>
+            <url>https://mavenrepo.cubekrowd.net/artifactory/public-release-local/</url>
+        </repository>
+        <snapshotRepository>
+            <id>cubekrowd-repo</id>
+            <name>cubekrowd-public-snapshots</name>
+            <url>https://mavenrepo.cubekrowd.net/artifactory/public-snapshot-local/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This pull request configures the automatic deployment and the destination where maven should deploy the plugin to. It should not affect the development process at all. Our CI/CD setup will then once per hour check for updates. When a new commit is detected it will clone the repository and deploy it to the maven repository.

If someone wants to use the VanishAPI in their plugin then they simply att the CK maven repo as a remote repository and specifies SuperVanish as a dependency:

```
    <repositories>
        <repository>
            <id>cubekrowd-repo</id>
            <url>https://mavenrepo.cubekrowd.net/artifactory/repo/</url>
        </repository>
    </repositories>

    <dependencies>
        <!-- SuperVanish -->
        <dependency>
            <groupId>de.myzelyam</groupId>
            <artifactId>SuperVanish</artifactId>
            <version>5.10.1</version>
            <scope>provided</scope>
        </dependency>
    </dependencies>
```