### PR TITLE
Do not use the JavaPlugin starting/disabling methods

### DIFF
--- a/src/main/java/de/myzelyam/supervanish/SuperVanish.java
+++ b/src/main/java/de/myzelyam/supervanish/SuperVanish.java
@@ -156,10 +156,12 @@ public class SuperVanish extends JavaPlugin implements SuperVanishPlugin {
     public void reload() {
         getServer().getScheduler().cancelTasks(this);
         HandlerList.unregisterAll(this);
+
         if (useProtocolLib)
             ProtocolLibrary.getProtocolManager().removePacketListeners(this);
-        onDisable();
-        onEnable();
+
+        getServer().getPluginManager().disablePlugin(this);
+        getServer().getPluginManager().enablePlugin(this);
     }
 
     @Override


### PR DESCRIPTION
This needs to be changed because the JavaPlugin default enable/disable methods should not be used to avoid errors. Therefore, we use safer methods to ensure that the plugin reload is correct.