### PR TITLE
Add an option to suppress death messages

### DIFF
--- a/src/main/java/de/myzelyam/supervanish/events/GeneralEventHandler.java
+++ b/src/main/java/de/myzelyam/supervanish/events/GeneralEventHandler.java
@@ -22,9 +22,9 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
-import org.bukkit.event.player.PlayerDeathEvent;
 
 
 public class GeneralEventHandler implements Listener {

--- a/src/main/java/de/myzelyam/supervanish/events/GeneralEventHandler.java
+++ b/src/main/java/de/myzelyam/supervanish/events/GeneralEventHandler.java
@@ -10,6 +10,7 @@ package de.myzelyam.supervanish.events;
 
 import de.myzelyam.supervanish.SuperVanish;
 import de.myzelyam.supervanish.VanishPlayer;
+import de.myzelyam.supervanish.features.Broadcast;
 
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
@@ -23,6 +24,8 @@ import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
+import org.bukkit.event.player.PlayerDeathEvent;
+
 
 public class GeneralEventHandler implements Listener {
 
@@ -47,6 +50,20 @@ public class GeneralEventHandler implements Listener {
                     plugin.sendMessage(p, "EntityHitDenied", p);
                     e.setCancelled(true);
                 }
+            }
+        } catch (Exception er) {
+            plugin.logException(er);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onPlayerDeath(PlayerDeathEvent e){
+        try {
+            if (!(e.getEntity() instanceof Player)) return;
+            Player p = (Player) e.getEntity();
+            if (plugin.getVanishStateMgr().isVanished(p.getUniqueId())) {
+                e.setDeathMessage(null);
+                Broadcast.announceSilentDeath(p, plugin);
             }
         } catch (Exception er) {
             plugin.logException(er);

--- a/src/main/java/de/myzelyam/supervanish/features/Broadcast.java
+++ b/src/main/java/de/myzelyam/supervanish/features/Broadcast.java
@@ -37,11 +37,12 @@ public class Broadcast extends Feature {
 
     public static void announceSilentDeath(Player p, SuperVanish plugin) {
         if (plugin.getSettings().getBoolean("MessageOptions.AnnounceDeathToAdmins", true)) {
-        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-            if (p == onlinePlayer)
-                continue;
-            if (plugin.canSee(onlinePlayer, p)) {
-                plugin.sendMessage(onlinePlayer, "SilentDeathMessage", p, onlinePlayer);
+            for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+                if (p == onlinePlayer)
+                    continue;
+                if (plugin.canSee(onlinePlayer, p)) {
+                    plugin.sendMessage(onlinePlayer, "SilentDeathMessage", p, onlinePlayer);
+                }
             }
         }
     }

--- a/src/main/java/de/myzelyam/supervanish/features/Broadcast.java
+++ b/src/main/java/de/myzelyam/supervanish/features/Broadcast.java
@@ -35,6 +35,17 @@ public class Broadcast extends Feature {
         }
     }
 
+    public static void announceSilentDeath(Player p, SuperVanish plugin) {
+        if (plugin.getSettings().getBoolean("MessageOptions.AnnounceDeathToAdmins", true)) {
+        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+            if (p == onlinePlayer)
+                continue;
+            if (plugin.canSee(onlinePlayer, p)) {
+                plugin.sendMessage(onlinePlayer, "SilentDeathMessage", p, onlinePlayer);
+            }
+        }
+    }
+
     public static void announceSilentQuit(Player p, SuperVanish plugin) {
         if (plugin.getSettings().getBoolean("MessageOptions.AnnounceRealJoinQuitToAdmins", true)) {
             for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -91,6 +91,9 @@ MessageOptions:
   # If the setting above is turned on, should players with the permission 'sv.see' get
   # a message when an invisible player joins/quits?
   AnnounceRealJoinQuitToAdmins: true
+  # If the setting above is turned on, should players with the permission 'sv.see' get
+  # a message when an invisible player dies
+  AnnounceDeathToAdmins: true
   # Should SV remind players who join the server vanished of being invisible (in chat)?
   # You can change the message in the messages.yml file.
   RemindVanishedOnJoin: true

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -38,6 +38,7 @@ Messages:
   NotVanishedError: '&cYou are not invisible!'
   SilentJoinMessageForAdmins: '&a[SV] %p% joined silently.'
   SilentQuitMessageForAdmins: '&a[SV] %p% left silently.'
+  SilentDeathMessage: '&a[SV] %p% has died'
   RemindingMessage: '&aYou are still invisible!'
   ListMessagePrefix: '&aInvisible Players:&f %l'
   ActionBarMessage: '&aYou are invisible to other players!'


### PR DESCRIPTION
This adds an event listener for `PlayerDeathEvent` and nullifies the death message if the player is vanished. It also checks for the config option `announceSilentDeath` , which would announce the death message to players with proper permissions. The message to be shown is taken from `SilentDeathMessage` property in messages.yml