### PR TITLE
Update deprecated methods from PlaceHolderAPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.2</version>
+            <version>2.10.6</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/de/myzelyam/supervanish/hooks/PlaceholderAPIExpansion.java
+++ b/src/main/java/de/myzelyam/supervanish/hooks/PlaceholderAPIExpansion.java
@@ -1,0 +1,81 @@
+package de.myzelyam.supervanish.hooks;
+
+import de.myzelyam.supervanish.SuperVanish;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+import java.util.UUID;
+
+public class PlaceholderAPIExpansion extends PlaceholderExpansion {
+
+    private final SuperVanish superVanish;
+
+    public PlaceholderAPIExpansion(SuperVanish superVanish) {
+        this.superVanish = superVanish;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "supervanish";
+    }
+
+    @Override
+    public String getAuthor() {
+        return "Myzelyam";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1.0.0";
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player p, String id) {
+        try {
+            if (id.equalsIgnoreCase("isvanished")
+                    || id.equalsIgnoreCase("isinvisible")
+                    || id.equalsIgnoreCase("vanished")
+                    || id.equalsIgnoreCase("invisible"))
+                return superVanish.getVanishStateMgr().isVanished(p.getUniqueId()) ? "Yes"
+                        : "No";
+            if (id.equalsIgnoreCase("onlinevanishedplayers")
+                    || id.equalsIgnoreCase("onlinevanished")
+                    || id.equalsIgnoreCase("invisibleplayers")
+                    || id.equalsIgnoreCase("vanishedplayers")
+                    || id.equalsIgnoreCase("hiddenplayers")) {
+                Collection<UUID> onlineVanishedPlayers = superVanish.getVanishStateMgr()
+                        .getOnlineVanishedPlayers();
+                String playerListMessage = "";
+                for (UUID uuid : onlineVanishedPlayers) {
+                    Player onlineVanished = Bukkit.getPlayer(uuid);
+                    if (onlineVanished == null) continue;
+                    if (superVanish.getSettings().getBoolean(
+                            "IndicationFeatures.LayeredPermissions.HideInvisibleInCommands", false)
+                            && !superVanish.hasPermissionToSee(p, onlineVanished)) {
+                        continue;
+                    }
+                    playerListMessage = playerListMessage + onlineVanished.getName() + ", ";
+                }
+                return playerListMessage.length() > 3
+                        ? playerListMessage.substring(0, playerListMessage.length() - 2)
+                        : playerListMessage;
+            }
+            if (id.equalsIgnoreCase("playercount")
+                    || id.equalsIgnoreCase("onlineplayers")) {
+                int playercount = Bukkit.getOnlinePlayers().size();
+                for (UUID uuid : superVanish.getVanishStateMgr()
+                        .getOnlineVanishedPlayers()) {
+                    Player onlineVanished = Bukkit.getPlayer(uuid);
+                    if (onlineVanished == null) continue;
+                    if (p == null || !superVanish.canSee(p, onlineVanished)) playercount--;
+                }
+                return playercount + "";
+            }
+        } catch (Exception e) {
+            superVanish.logException(e);
+        }
+        return "";
+    }
+}

--- a/src/main/java/de/myzelyam/supervanish/hooks/PlaceholderAPIHook.java
+++ b/src/main/java/de/myzelyam/supervanish/hooks/PlaceholderAPIHook.java
@@ -10,20 +10,18 @@ package de.myzelyam.supervanish.hooks;
 
 import de.myzelyam.supervanish.SuperVanish;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
-import java.util.Collection;
-import java.util.UUID;
-
 import me.clip.placeholderapi.PlaceholderAPI;
-import me.clip.placeholderapi.PlaceholderHook;
 
 public class PlaceholderAPIHook extends PluginHook {
 
+    private final PlaceholderAPIExpansion expansion;
+
     public PlaceholderAPIHook(SuperVanish superVanish) {
         super(superVanish);
+        this.expansion = new PlaceholderAPIExpansion(superVanish);
     }
 
     public static String translatePlaceholders(String msg, Player p) {
@@ -32,55 +30,14 @@ public class PlaceholderAPIHook extends PluginHook {
 
     @Override
     public void onPluginEnable(Plugin plugin) {
-        PlaceholderAPI.unregisterPlaceholderHook(superVanish);
-        PlaceholderAPI.registerPlaceholderHook(superVanish, new PlaceholderHook() {
-            @Override
-            public String onPlaceholderRequest(Player p, String id) {
-                try {
-                    if (id.equalsIgnoreCase("isvanished")
-                            || id.equalsIgnoreCase("isinvisible")
-                            || id.equalsIgnoreCase("vanished")
-                            || id.equalsIgnoreCase("invisible"))
-                        return superVanish.getVanishStateMgr().isVanished(p.getUniqueId()) ? "Yes"
-                                : "No";
-                    if (id.equalsIgnoreCase("onlinevanishedplayers")
-                            || id.equalsIgnoreCase("onlinevanished")
-                            || id.equalsIgnoreCase("invisibleplayers")
-                            || id.equalsIgnoreCase("vanishedplayers")
-                            || id.equalsIgnoreCase("hiddenplayers")) {
-                        Collection<UUID> onlineVanishedPlayers = superVanish.getVanishStateMgr()
-                                .getOnlineVanishedPlayers();
-                        String playerListMessage = "";
-                        for (UUID uuid : onlineVanishedPlayers) {
-                            Player onlineVanished = Bukkit.getPlayer(uuid);
-                            if (onlineVanished == null) continue;
-                            if (superVanish.getSettings().getBoolean(
-                                    "IndicationFeatures.LayeredPermissions.HideInvisibleInCommands", false)
-                                    && !superVanish.hasPermissionToSee(p, onlineVanished)) {
-                                continue;
-                            }
-                            playerListMessage = playerListMessage + onlineVanished.getName() + ", ";
-                        }
-                        return playerListMessage.length() > 3
-                                ? playerListMessage.substring(0, playerListMessage.length() - 2)
-                                : playerListMessage;
-                    }
-                    if (id.equalsIgnoreCase("playercount")
-                            || id.equalsIgnoreCase("onlineplayers")) {
-                        int playercount = Bukkit.getOnlinePlayers().size();
-                        for (UUID uuid : superVanish.getVanishStateMgr()
-                                .getOnlineVanishedPlayers()) {
-                            Player onlineVanished = Bukkit.getPlayer(uuid);
-                            if (onlineVanished == null) continue;
-                            if (p == null || !superVanish.canSee(p, onlineVanished)) playercount--;
-                        }
-                        return playercount + "";
-                    }
-                } catch (Exception e) {
-                    superVanish.logException(e);
-                }
-                return "";
-            }
-        });
+        onPluginDisable(plugin);
+        expansion.register();
+    }
+
+    @Override
+    public void onPluginDisable(Plugin plugin) {
+        if (expansion.isRegistered()) {
+            PlaceholderAPI.unregisterExpansion(expansion);
+        }
     }
 }


### PR DESCRIPTION
As of one of the latest dev builds of PlaceholderAPI, the deprecated methods `PlaceholderAPI#registerPlaceholderHook` and `PlaceholderAPI#unregisterPlaceholderHook` have been removed from the API. Therefore the PlaceholderAPI hook has been split up into two classes, a placeholder "expansion" and the actual hook.